### PR TITLE
Minor corrections to OpenBSD logic

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -532,7 +532,7 @@ else
 build_shlibdir := $(build_libdir)
 endif
 
-ifeq (,$(findstring $(OS),FreeBSD OpenBSD))
+ifneq (,$(findstring $(OS),FreeBSD OpenBSD))
 LOCALBASE ?= /usr/local
 else
 LOCALBASE ?= /usr
@@ -547,7 +547,7 @@ endif
 
 # A bit of a kludge to work around libraries linking to FreeBSD's outdated system libgcc_s
 # Instead, let's link to the libgcc_s corresponding to the installation of gfortran
-ifeq (,$(findstring $(OS),FreeBSD OpenBSD))
+ifneq (,$(findstring $(OS),FreeBSD OpenBSD))
 ifneq (,$(findstring gfortran,$(FC)))
 
 # First let's figure out what version of GCC we're dealing with

--- a/base/repl/Terminals.jl
+++ b/base/repl/Terminals.jl
@@ -156,7 +156,7 @@ else
     function hascolor(t::TTYTerminal)
         startswith(t.term_type, "xterm") && return true
         try
-            @static if Sys.KERNEL _ (:FreeBSD, :OpenBSD)
+            @static if Sys.KERNEL in (:FreeBSD, :OpenBSD)
                 return success(`tput AF 0`)
             else
                 return success(`tput setaf 0`)

--- a/src/Makefile
+++ b/src/Makefile
@@ -31,11 +31,7 @@ else
 FLAGS += -DJL_BUILD_UNAME='"$(OS)"'
 endif
 
-ifeq ($(OS),FreeBSD)
-FLAGS += -I$(LOCALBASE)/include
-endif
-
-ifeq($(OS),OpenBSD)
+ifneq (,$(findstring $(OS),FreeBSD OpenBSD))
 FLAGS += -I$(LOCALBASE)/include
 endif
 


### PR DESCRIPTION
Just a couple little things. Most notably, the checks on `$(findstring $(OS),...)` in the Make logic should be `ifneq` since the comparison is against the empty string.

It also looks like you have OpenBSD going through the code path that FreeBSD needs to work around [the libgcc_s issue](https://wiki.freebsd.org/libgcc%20problem). That's also an issue with OpenBSD? If so, that's quite unfortunate, but also you'll want to add OpenBSD to the logic that links in `-lgcc_s` later on FreeBSD.

Hope this helps!